### PR TITLE
Add level check for disciplines

### DIFF
--- a/MQ2Melee.cpp
+++ b/MQ2Melee.cpp
@@ -2444,6 +2444,11 @@ public:
                         EFFECT = spell;
                         REUSE = spell->CastTime + spell->RecastTime + delay * 6;
                         TYPE = DISC;
+                        if (pLocalPlayer) {
+                            if (pLocalPlayer->Level < spell->ClassLevel[GetPcProfile()->Class]) {
+                                return false;
+                            }
+                        }
                         return true;
                     }
                 }


### PR DESCRIPTION
Found if you had a discipline and were a lower level than that discipline, it still tried to use it